### PR TITLE
update import of HypermediaResource to allow pip install for python3

### DIFF
--- a/hypermedia_resource/__init__.py
+++ b/hypermedia_resource/__init__.py
@@ -3,4 +3,4 @@ __version__ = '0.1.11'
 __author__ = 'Stephen Mizell'
 __license__ = 'MIT'
 
-from resource import HypermediaResource
+from .resource import HypermediaResource


### PR DESCRIPTION
Adding this single character allows a package user to install via pip in python3.
