### PR TITLE
Add Python 3.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
 python:
   - 2.7
+  - 3.6
 script: nosetests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: python
 python:
   - 2.7
-  - 3.6
 script: nosetests

--- a/representor/__init__.py
+++ b/representor/__init__.py
@@ -3,4 +3,4 @@ __version__ = '0.3.1'
 __author__ = 'Stephen Mizell'
 __license__ = 'MIT'
 
-from resource import Representor
+from representor.resource import Representor

--- a/representor/adapters/hale_json.py
+++ b/representor/adapters/hale_json.py
@@ -12,17 +12,17 @@ def parse_attributes(hal_rep, resource):
 def parse_link(rel, link, resource):
     if "templated" in link and link["templated"]:
         return
-    if (link.has_key("method") and link["method"] != "GET"):
+    if link.get("method", "GET") != "GET":
         resource = resource.actions.add(rel, link["href"], link["method"])
     else:
         resource = resource.links.add(rel=rel, href=link["href"])
-    if link.has_key("request_encoding"):
+    if "request_encoding" in link:
         resource.response_types.add(link["request_encoding"])
-    if link.has_key("data"):
+    if "data" in link:
         # Right now, it only supports name and values
         for name, value in link["data"].items():
             attr = resource.attributes.add(name)
-            if value.has_key("options"):
+            if 'options' in value:
                 for option in value["options"]:
                     attr.options.add(option, option)
     return resource


### PR DESCRIPTION
Unfortunately this is blocked by https://github.com/CottageLabs/negotiator/pull/2 which causes a test failure since negotiator has not been updated for Python 3.